### PR TITLE
fix warnings with V 0.1.29 4bc38a2; run vfmt over *.v

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pdb
+semver_test

--- a/compare.v
+++ b/compare.v
@@ -1,78 +1,61 @@
 module semver
 
-/*
- * Private functions.
- */
-
+// * Private functions.
 [inline]
 fn version_satisfies(ver Version, input string) bool {
 	range := parse_range(input) or {
 		return false
 	}
-
 	return range.satisfies(ver)
 }
 
-fn compare_eq(v1, v2 Version) bool {
-	return
-		v1.major == v2.major &&
-		v1.minor == v2.minor &&
-		v1.patch == v2.patch &&
-		v1.prerelease == v2.prerelease
+fn compare_eq(v1 Version, v2 Version) bool {
+	return v1.major == v2.major &&
+		v1.minor == v2.minor && v1.patch == v2.patch && v1.prerelease == v2.prerelease
 }
 
-fn compare_gt(v1, v2 Version) bool {
+fn compare_gt(v1 Version, v2 Version) bool {
 	if v1.major < v2.major {
 		return false
 	}
-
 	if v1.major > v2.major {
 		return true
 	}
-
 	if v1.minor < v2.minor {
 		return false
 	}
-
 	if v1.minor > v2.minor {
 		return true
 	}
-
 	return v1.patch > v2.patch
 }
 
-fn compare_lt(v1, v2 Version) bool {
+fn compare_lt(v1 Version, v2 Version) bool {
 	if v1.major > v2.major {
 		return false
 	}
-
 	if v1.major < v2.major {
 		return true
 	}
-
 	if v1.minor > v2.minor {
 		return false
 	}
-
 	if v1.minor < v2.minor {
 		return true
 	}
-
 	return v1.patch < v2.patch
 }
 
-fn compare_ge(v1, v2 Version) bool {
+fn compare_ge(v1 Version, v2 Version) bool {
 	if compare_eq(v1, v2) {
 		return true
 	}
-
 	return compare_gt(v1, v2)
 }
 
-fn compare_le(v1, v2 Version) bool {
+fn compare_le(v1 Version, v2 Version) bool {
 	if compare_eq(v1, v2) {
 		return true
 	}
-
 	return compare_lt(v1, v2)
 }

--- a/parse.v
+++ b/parse.v
@@ -1,47 +1,42 @@
 module semver
 
-/*
- * Private structs and functions.
- */
-
+// * Private structs and functions.
 struct RawVersion {
 	prerelease string
-	metadata string
+	metadata   string
 mut:
-	raw_ints []string
+	raw_ints   []string
 }
 
 const (
 	ver_major = 0
 	ver_minor = 1
 	ver_patch = 2
-
-	versions = [ver_major, ver_minor, ver_patch]
+	versions  = [ver_major, ver_minor, ver_patch]
 )
 
 // TODO: Rewrite using regexps?
 // /(\d+)\.(\d+)\.(\d+)(?:\-([0-9A-Za-z-.]+))?(?:\+([0-9A-Za-z-]+))?/
-
 fn parse(input string) RawVersion {
 	mut raw_version := input
 	mut prerelease := ''
 	mut metadata := ''
-
-	plus_idx := raw_version.last_index('+') or { -1 }
+	plus_idx := raw_version.last_index('+') or {
+		-1
+	}
 	if plus_idx > 0 {
 		metadata = raw_version[(plus_idx + 1)..]
 		raw_version = raw_version[0..plus_idx]
 	}
-
-	hyphen_idx := raw_version.index('-') or { -1 }
+	hyphen_idx := raw_version.index('-') or {
+		-1
+	}
 	if hyphen_idx > 0 {
 		prerelease = raw_version[(hyphen_idx + 1)..]
 		raw_version = raw_version[0..hyphen_idx]
 	}
-
 	raw_ints := raw_version.split('.')
-
-	return RawVersion {
+	return RawVersion{
 		prerelease: prerelease
 		metadata: metadata
 		raw_ints: raw_ints
@@ -52,13 +47,8 @@ fn (ver RawVersion) is_valid() bool {
 	if ver.raw_ints.len != 3 {
 		return false
 	}
-
-	return
-		is_valid_number(ver.raw_ints[ver_major]) &&
-		is_valid_number(ver.raw_ints[ver_minor]) &&
-		is_valid_number(ver.raw_ints[ver_patch]) &&
-		is_valid_string(ver.prerelease) &&
-		is_valid_string(ver.metadata)
+	return is_valid_number(ver.raw_ints[ver_major]) && is_valid_number(ver.raw_ints[ver_minor]) &&
+		is_valid_number(ver.raw_ints[ver_patch]) && is_valid_string(ver.prerelease) && is_valid_string(ver.metadata)
 }
 
 fn (ver RawVersion) is_missing(typ int) bool {
@@ -67,11 +57,9 @@ fn (ver RawVersion) is_missing(typ int) bool {
 
 fn (raw_ver RawVersion) coerce() ?Version {
 	ver := raw_ver.complete()
-
 	if !is_valid_number(ver.raw_ints[ver_major]) {
 		return error('Invalid major version: $ver.raw_ints[ver_major]')
 	}
-
 	return ver.to_version()
 }
 
@@ -80,8 +68,7 @@ fn (raw_ver RawVersion) complete() RawVersion {
 	for raw_ints.len < 3 {
 		raw_ints << '0'
 	}
-
-	return RawVersion {
+	return RawVersion{
 		prerelease: raw_ver.prerelease
 		metadata: raw_ver.metadata
 		raw_ints: raw_ints
@@ -92,16 +79,9 @@ fn (raw_ver RawVersion) validate() ?Version {
 	if !raw_ver.is_valid() {
 		return none
 	}
-
 	return raw_ver.to_version()
 }
 
 fn (raw_ver RawVersion) to_version() Version {
-	return Version {
-		raw_ver.raw_ints[ver_major].int(),
-		raw_ver.raw_ints[ver_minor].int(),
-		raw_ver.raw_ints[ver_patch].int(),
-		raw_ver.prerelease,
-		raw_ver.metadata
-	}
+	return Version{raw_ver.raw_ints[ver_major].int(), raw_ver.raw_ints[ver_minor].int(), raw_ver.raw_ints[ver_patch].int(), raw_ver.prerelease, raw_ver.metadata}
 }

--- a/range.v
+++ b/range.v
@@ -1,21 +1,24 @@
 module semver
 
-/*
- * Private functions.
- */
-
+// * Private functions.
 const (
-	comparator_sep = ' '
+	comparator_sep     = ' '
 	comparator_set_sep = ' || '
-	hyphen_range_sep = ' - '
-	x_range_symbols = 'Xx*'
+	hyphen_range_sep   = ' - '
+	x_range_symbols    = 'Xx*'
 )
 
-enum Operator { gt lt ge le eq }
+enum Operator {
+	gt
+	lt
+	ge
+	le
+	eq
+}
 
 struct Comparator {
 	ver Version
-	op Operator
+	op  Operator
 }
 
 struct ComparatorSet {
@@ -28,11 +31,9 @@ struct Range {
 
 fn (r Range) satisfies(ver Version) bool {
 	mut final_result := false
-
 	for set in r.comparator_sets {
 		final_result = final_result || set.satisfies(ver)
 	}
-
 	return final_result
 }
 
@@ -42,34 +43,22 @@ fn (set ComparatorSet) satisfies(ver Version) bool {
 			return false
 		}
 	}
-
 	return true
 }
 
 fn (c Comparator) satisfies(ver Version) bool {
 	return match c.op {
-		.gt {
-			ver.gt(c.ver)
-		}
-		.lt {
-			ver.lt(c.ver)
-		}
-		.ge {
-			ver.ge(c.ver)
-		}
-		.le {
-			ver.le(c.ver)
-		}
-		.eq {
-			ver.eq(c.ver)
-		}
+		.gt { ver.gt(c.ver) }
+		.lt { ver.lt(c.ver) }
+		.ge { ver.ge(c.ver) }
+		.le { ver.le(c.ver) }
+		.eq { ver.eq(c.ver) }
 	}
 }
 
 fn parse_range(input string) ?Range {
 	raw_comparator_sets := input.split(comparator_set_sep)
 	mut comparator_sets := []ComparatorSet{}
-
 	for raw_comp_set in raw_comparator_sets {
 		if can_expand(raw_comp_set) {
 			s := expand_comparator_set(raw_comp_set) or {
@@ -83,8 +72,7 @@ fn parse_range(input string) ?Range {
 			comparator_sets << s
 		}
 	}
-
-	return Range { comparator_sets }
+	return Range{comparator_sets}
 }
 
 fn parse_comparator_set(input string) ?ComparatorSet {
@@ -92,23 +80,19 @@ fn parse_comparator_set(input string) ?ComparatorSet {
 	if raw_comparators.len > 2 {
 		return error('Invalid format of comparator set')
 	}
-
 	mut comparators := []Comparator{}
 	for raw_comp in raw_comparators {
 		c := parse_comparator(raw_comp) or {
 			return error('Invalid comparator: $raw_comp')
 		}
-
 		comparators << c
 	}
-
-	return ComparatorSet { comparators }
+	return ComparatorSet{comparators}
 }
 
 fn parse_comparator(input string) ?Comparator {
 	mut op := Operator.eq
 	mut raw_version := ''
-
 	if input.starts_with('>=') {
 		op = .ge
 		raw_version = input[2..]
@@ -126,21 +110,18 @@ fn parse_comparator(input string) ?Comparator {
 	} else {
 		raw_version = input
 	}
-
 	version := coerce_version(raw_version) or {
 		return none
 	}
-	return Comparator { version, op }
+	return Comparator{version, op}
 }
 
 fn parse_xrange(input string) ?Version {
 	mut raw_ver := parse(input).complete()
-
 	for typ in versions {
 		if raw_ver.raw_ints[typ].index_any(x_range_symbols) == -1 {
 			continue
 		}
-
 		match typ {
 			ver_major {
 				raw_ver.raw_ints[ver_major] = '0'
@@ -157,35 +138,26 @@ fn parse_xrange(input string) ?Version {
 			else {}
 		}
 	}
-
 	if !raw_ver.is_valid() {
 		return none
 	}
-
 	return raw_ver.to_version()
 }
 
 fn can_expand(input string) bool {
-	return
-		input[0] == `~` || input[0] == `^` ||
-		input.contains(hyphen_range_sep) || input.index_any(x_range_symbols) > -1
+	return input[0] == `~` ||
+		input[0] == `^` || input.contains(hyphen_range_sep) || input.index_any(x_range_symbols) > -1
 }
 
 fn expand_comparator_set(input string) ?ComparatorSet {
 	match input[0] {
-		`~` {
-			return expand_tilda(input[1..])
-		}
-		`^` {
-			return expand_caret(input[1..])
-		}
+		`~` { return expand_tilda(input[1..]) }
+		`^` { return expand_caret(input[1..]) }
 		else {}
 	}
-
 	if input.contains(hyphen_range_sep) {
 		return expand_hyphen(input)
 	}
-
 	return expand_xrange(input)
 }
 
@@ -194,13 +166,11 @@ fn expand_tilda(raw_version string) ?ComparatorSet {
 		return none
 	}
 	mut max_ver := min_ver
-
 	if min_ver.minor == 0 && min_ver.patch == 0 {
 		max_ver = min_ver.increment(.major)
 	} else {
 		max_ver = min_ver.increment(.minor)
 	}
-
 	return make_comparator_set_ge_lt(min_ver, max_ver)
 }
 
@@ -208,15 +178,12 @@ fn expand_caret(raw_version string) ?ComparatorSet {
 	min_ver := coerce_version(raw_version) or {
 		return none
 	}
-
 	mut max_ver := min_ver
-
 	if min_ver.major == 0 {
 		max_ver = min_ver.increment(.minor)
 	} else {
 		max_ver = min_ver.increment(.major)
 	}
-
 	return make_comparator_set_ge_lt(min_ver, max_ver)
 }
 
@@ -225,25 +192,20 @@ fn expand_hyphen(raw_range string) ?ComparatorSet {
 	if raw_versions.len != 2 {
 		return none
 	}
-
 	min_ver := coerce_version(raw_versions[0]) or {
 		return none
 	}
-
 	raw_max_ver := parse(raw_versions[1])
 	if raw_max_ver.is_missing(ver_major) {
 		return none
 	}
-
 	mut max_ver := raw_max_ver.coerce() or {
 		return none
 	}
-
 	if raw_max_ver.is_missing(ver_minor) {
 		max_ver = max_ver.increment(.minor)
 		return make_comparator_set_ge_lt(min_ver, max_ver)
 	}
-
 	return make_comparator_set_ge_le(min_ver, max_ver)
 }
 
@@ -251,40 +213,33 @@ fn expand_xrange(raw_range string) ?ComparatorSet {
 	min_ver := parse_xrange(raw_range) or {
 		return none
 	}
-
 	if min_ver.major == 0 {
 		comparators := [
-			Comparator { min_ver, Operator.ge },
+			Comparator{min_ver, Operator.ge},
 		]
-
-		return ComparatorSet { comparators }
+		return ComparatorSet{comparators}
 	}
-
 	mut max_ver := min_ver
-
 	if min_ver.minor == 0 {
 		max_ver = min_ver.increment(.major)
 	} else {
 		max_ver = min_ver.increment(.minor)
 	}
-
 	return make_comparator_set_ge_lt(min_ver, max_ver)
 }
 
-fn make_comparator_set_ge_lt(min, max Version) ComparatorSet {
+fn make_comparator_set_ge_lt(min Version, max Version) ComparatorSet {
 	comparators := [
-		Comparator { min, Operator.ge },
-		Comparator { max, Operator.lt }
+		Comparator{min, Operator.ge},
+		Comparator{max, Operator.lt},
 	]
-
-	return ComparatorSet { comparators }
+	return ComparatorSet{comparators}
 }
 
-fn make_comparator_set_ge_le(min, max Version) ComparatorSet {
+fn make_comparator_set_ge_le(min Version, max Version) ComparatorSet {
 	comparators := [
-		Comparator { min, Operator.ge },
-		Comparator { max, Operator.le }
+		Comparator{min, Operator.ge},
+		Comparator{max, Operator.le},
 	]
-
-	return ComparatorSet { comparators }
+	return ComparatorSet{comparators}
 }

--- a/semver.v
+++ b/semver.v
@@ -1,65 +1,50 @@
-/*
- * Documentation: https://docs.npmjs.com/misc/semver
- */
-
+// * Documentation: https://docs.npmjs.com/misc/semver
 module semver
 
-/*
- * Structures.
- */
-
+// * Structures.
 // Structure representing version in semver format.
 pub struct Version {
 pub:
-	major int
-	minor int
-	patch int
-	prerelease string = ''
-	metadata string = ''
+	major      int
+	minor      int
+	patch      int
+	prerelease string
+	metadata   string
 }
 
 // Enum representing type of version increment.
 pub enum Increment {
-	major minor patch
+	major
+	minor
+	patch
 }
 
-/*
- * Constructor.
- */
-
+// * Constructor.
 // from returns Version structure parsed from input string.
 pub fn from(input string) ?Version {
 	if input.len == 0 {
 		return error('Empty input')
 	}
-
 	raw_version := parse(input)
 	version := raw_version.validate() or {
 		return error('Invalid version format')
 	}
-
 	return version
 }
 
 // build returns Version structure with given major, minor and patch versions.
-pub fn build(major, minor, patch int) Version {
+pub fn build(major int, minor int, patch int) Version {
 	// TODO Check if versions are greater than zero.
-	return Version { major, minor, patch, '', '' }
+	return Version{major, minor, patch, '', ''}
 }
 
-/*
- * Transformation.
- */
-
+// * Transformation.
 // increment returns Version structure with incremented values.
 pub fn (ver Version) increment(typ Increment) Version {
 	return increment_version(ver, typ)
 }
 
-/*
- * Comparison.
- */
-
+// * Comparison.
 pub fn (ver Version) satisfies(input string) bool {
 	return version_satisfies(ver, input)
 }
@@ -84,15 +69,11 @@ pub fn (v1 Version) le(v2 Version) bool {
 	return compare_le(v1, v2)
 }
 
-/*
- * Utilites.
- */
-
+// * Utilites.
 pub fn coerce(input string) ?Version {
 	ver := coerce_version(input) or {
 		return error('Invalid version: $input')
 	}
-
 	return ver
 }
 

--- a/semver_test.v
+++ b/semver_test.v
@@ -1,181 +1,78 @@
 import semver
 
 struct TestVersion {
-	raw string
-	major int
-	minor int
-	patch int
+	raw        string
+	major      int
+	minor      int
+	patch      int
 	prerelease string
-	metadata string
+	metadata   string
 }
 
 struct TestRange {
-	raw_version string
-	range_satisfied string
+	raw_version       string
+	range_satisfied   string
 	range_unsatisfied string
 }
 
 struct TestCoerce {
 	invalid string
-	valid string
+	valid   string
 }
 
 const (
-	versions_to_test = [
-		TestVersion {
-			'1.2.4',
-			1, 2, 4, '', ''
-		},
-		TestVersion {
-			'1.2.4-prerelease-1',
-			1, 2, 4, 'prerelease-1', ''
-		},
-		TestVersion {
-			'1.2.4+20191231',
-			1, 2, 4, '', '20191231'
-		},
-		TestVersion {
-			'1.2.4-prerelease-1+20191231',
-			1, 2, 4, 'prerelease-1', '20191231'
-		},
-		TestVersion {
-			'1.2.4+20191231-prerelease-1',
-			1, 2, 4, '', '20191231-prerelease-1'
-		}
+	versions_to_test         = [
+		TestVersion{'1.2.4', 1, 2, 4, '', ''},
+		TestVersion{'1.2.4-prerelease-1', 1, 2, 4, 'prerelease-1', ''},
+		TestVersion{'1.2.4+20191231', 1, 2, 4, '', '20191231'},
+		TestVersion{'1.2.4-prerelease-1+20191231', 1, 2, 4, 'prerelease-1', '20191231'},
+		TestVersion{'1.2.4+20191231-prerelease-1', 1, 2, 4, '', '20191231-prerelease-1'},
 	]
-
-	ranges_to_test = [
-		TestRange {
-			'1.1.0',
-			'1.1.0',
-			'1.1.1',
-		},
-		TestRange {
-			'1.1.0',
-			'=1.1.0',
-			'=1.1.1',
-		},
-		TestRange {
-			'1.1.0',
-			'>=1.0.0',
-			'<1.1.0',
-		},
-		TestRange {
-			'1.1.0',
-			'>=1.0.0 <=1.1.0',
-			'>=1.0.0 <1.1.0',
-		},
-		TestRange {
-			'2.3.1',
-			'>=1.0.0 <=1.1.0 || >2.0.0 <2.3.4',
-			'>=1.0.0 <1.1.0',
-		},
-		TestRange {
-			'2.3.1',
-			'>=1.0.0 <=1.1.0 || >2.0.0 <2.3.4',
-			'>=1.0.0 <1.1.0 || >4.0.0 <5.0.0',
-		},
-		TestRange {
-			'2.3.1',
-			'~2.3.0',
-			'~2.4.0',
-		},
-		TestRange {
-			'3.0.0',
-			'~3.0.0',
-			'~4.0.0',
-		},
-		TestRange {
-			'2.3.1',
-			'^2.0.0',
-			'^2.4.0',
-		},
-		TestRange {
-			'0.3.1',
-			'^0.3.0',
-			'^2.4.0',
-		},
-		TestRange {
-			'0.0.4',
-			'^0.0.1',
-			'^0.1.0',
-		},
-		TestRange {
-			'2.3.4',
-			'^0.0.1 || ^2.3.0',
-			'^3.1.0 || ^4.2.0',
-		},
-		TestRange {
-			'2.3.4',
-			'>2 || <3',
-			'>3 || >4',
-		},
-		TestRange {
-			'2.3.4',
-			'2.3.4 - 2.3.5',
-			'2.5.1 - 2.8.3',
-		},
-		TestRange {
-			'2.3.4',
-			'2.2 - 2.3',
-			'2.4 - 2.8',
-		},
-		TestRange {
-			'2.3.4',
-			'2.3.x',
-			'2.4.x',
-		},
-		TestRange {
-			'2.3.4',
-			'2.x',
-			'3.x',
-		},
-		TestRange {
-			'2.3.4',
-			'*',
-			'3.x',
-		}
+	ranges_to_test           = [
+		TestRange{'1.1.0', '1.1.0', '1.1.1'},
+		TestRange{'1.1.0', '=1.1.0', '=1.1.1'},
+		TestRange{'1.1.0', '>=1.0.0', '<1.1.0'},
+		TestRange{'1.1.0', '>=1.0.0 <=1.1.0', '>=1.0.0 <1.1.0'},
+		TestRange{'2.3.1', '>=1.0.0 <=1.1.0 || >2.0.0 <2.3.4', '>=1.0.0 <1.1.0'},
+		TestRange{'2.3.1', '>=1.0.0 <=1.1.0 || >2.0.0 <2.3.4', '>=1.0.0 <1.1.0 || >4.0.0 <5.0.0'},
+		TestRange{'2.3.1', '~2.3.0', '~2.4.0'},
+		TestRange{'3.0.0', '~3.0.0', '~4.0.0'},
+		TestRange{'2.3.1', '^2.0.0', '^2.4.0'},
+		TestRange{'0.3.1', '^0.3.0', '^2.4.0'},
+		TestRange{'0.0.4', '^0.0.1', '^0.1.0'},
+		TestRange{'2.3.4', '^0.0.1 || ^2.3.0', '^3.1.0 || ^4.2.0'},
+		TestRange{'2.3.4', '>2 || <3', '>3 || >4'},
+		TestRange{'2.3.4', '2.3.4 - 2.3.5', '2.5.1 - 2.8.3'},
+		TestRange{'2.3.4', '2.2 - 2.3', '2.4 - 2.8'},
+		TestRange{'2.3.4', '2.3.x', '2.4.x'},
+		TestRange{'2.3.4', '2.x', '3.x'},
+		TestRange{'2.3.4', '*', '3.x'},
 	]
-
-	coerce_to_test = [
-		TestCoerce {
-			'1.2.0.4',
-			'1.2.0'
-		},
-		TestCoerce {
-			'1.2.0',
-			'1.2.0'
-		},
-		TestCoerce {
-			'1.2',
-			'1.2.0'
-		},
-		TestCoerce {
-			'1',
-			'1.0.0'
-		},
-		TestCoerce {
-			'1-alpha',
-			'1.0.0-alpha'
-		},
-		TestCoerce {
-			'1+meta',
-			'1.0.0+meta'
-		},
-		TestCoerce {
-			'1-alpha+meta',
-			'1.0.0-alpha+meta'
-		}
+	coerce_to_test           = [
+		TestCoerce{'1.2.0.4', '1.2.0'},
+		TestCoerce{'1.2.0', '1.2.0'},
+		TestCoerce{'1.2', '1.2.0'},
+		TestCoerce{'1', '1.0.0'},
+		TestCoerce{'1-alpha', '1.0.0-alpha'},
+		TestCoerce{'1+meta', '1.0.0+meta'},
+		TestCoerce{'1-alpha+meta', '1.0.0-alpha+meta'},
 	]
-
 	invalid_versions_to_test = [
-		'a.b.c', '1.2', '1.2.x', '1.2.3.4', '1.2.3-alpha@', '1.2.3+meta%'
+		'a.b.c',
+		'1.2',
+		'1.2.x',
+		'1.2.3.4',
+		'1.2.3-alpha@',
+		'1.2.3+meta%',
 	]
-
-	invalid_ranges_to_test = [
-		'^a', '~b', 'a - c', '>a', 'a', 'a.x'
+	invalid_ranges_to_test   = [
+		'^a',
+		'~b',
+		'a - c',
+		'>a',
+		'a',
+		'a.x',
 	]
-
 )
 
 fn test_from() {
@@ -184,37 +81,31 @@ fn test_from() {
 			assert false
 			return
 		}
-
 		assert ver.major == item.major
 		assert ver.minor == item.minor
 		assert ver.patch == item.patch
 		assert ver.metadata == item.metadata
 		assert ver.prerelease == item.prerelease
 	}
-
 	for ver in invalid_versions_to_test {
 		semver.from(ver) or {
 			assert true
 			continue
 		}
-
 		assert false
 	}
 }
 
 fn test_increment() {
 	version1 := semver.build(1, 2, 3)
-
 	version1_inc := version1.increment(.major)
 	assert version1_inc.major == 2
 	assert version1_inc.minor == 0
 	assert version1_inc.patch == 0
-
 	version2_inc := version1.increment(.minor)
 	assert version2_inc.major == 1
 	assert version2_inc.minor == 3
 	assert version2_inc.patch == 0
-
 	version3_inc := version1.increment(.patch)
 	assert version3_inc.major == 1
 	assert version3_inc.minor == 2
@@ -226,27 +117,22 @@ fn test_compare() {
 	patch := semver.build(1, 0, 1)
 	minor := semver.build(1, 2, 3)
 	major := semver.build(2, 0, 0)
-
 	assert first.le(first)
 	assert first.ge(first)
 	assert !first.lt(first)
 	assert !first.gt(first)
-
 	assert patch.ge(first)
 	assert first.le(patch)
 	assert !first.ge(patch)
 	assert !patch.le(first)
-
 	assert patch.gt(first)
 	assert first.lt(patch)
 	assert !first.gt(patch)
 	assert !patch.lt(first)
-
 	assert minor.gt(patch)
 	assert patch.lt(minor)
 	assert !patch.gt(minor)
 	assert !minor.lt(patch)
-
 	assert major.gt(minor)
 	assert minor.lt(major)
 	assert !minor.gt(major)
@@ -259,7 +145,6 @@ fn test_satisfies() {
 			assert false
 			return
 		}
-
 		assert ver.satisfies(item.range_satisfied)
 		assert !ver.satisfies(item.range_unsatisfied)
 	}
@@ -270,7 +155,6 @@ fn test_satisfies_invalid() {
 		assert false
 		return
 	}
-
 	for item in invalid_ranges_to_test {
 		assert ver.satisfies(item) == false
 	}
@@ -282,7 +166,6 @@ fn test_coerce() {
 			assert false
 			return
 		}
-
 		fixed := semver.coerce(item.invalid) or {
 			assert false
 			return
@@ -303,7 +186,6 @@ fn test_is_valid() {
 	for item in versions_to_test {
 		assert semver.is_valid(item.raw)
 	}
-
 	for item in invalid_versions_to_test {
 		assert semver.is_valid(item) == false
 	}

--- a/util.v
+++ b/util.v
@@ -1,9 +1,6 @@
 module semver
 
-/*
- * Private functions.
- */
-
+// * Private functions.
 [inline]
 fn is_version_valid(input string) bool {
 	raw_ver := parse(input)
@@ -24,7 +21,6 @@ fn increment_version(ver Version, typ Increment) Version {
 	mut major := ver.major
 	mut minor := ver.minor
 	mut patch := ver.patch
-
 	match typ {
 		.major {
 			major++
@@ -39,8 +35,7 @@ fn increment_version(ver Version, typ Increment) Version {
 			patch++
 		}
 	}
-
-	return Version { major, minor, patch, ver.prerelease, ver.metadata }
+	return Version{major, minor, patch, ver.prerelease, ver.metadata}
 }
 
 fn is_valid_string(input string) bool {
@@ -49,7 +44,6 @@ fn is_valid_string(input string) bool {
 			return false
 		}
 	}
-
 	return true
 }
 
@@ -59,6 +53,5 @@ fn is_valid_number(input string) bool {
 			return false
 		}
 	}
-
 	return true
 }


### PR DESCRIPTION
With this PR, `v -prod -stats test .` and `v vet .` run with no
warnings.